### PR TITLE
fix: resolve duplicate key warning in RightDetailPanel

### DIFF
--- a/src/components/Layout/RightDetailPanel.tsx
+++ b/src/components/Layout/RightDetailPanel.tsx
@@ -45,6 +45,7 @@ export function RightDetailPanel({ location, days, selectedDayId, onClose, onAdd
   return (
     <AnimatePresence>
       <motion.aside
+        key={location.id}
         initial={{ x: 400, opacity: 0 }}
         animate={{ x: 0, opacity: 1 }}
         exit={{ x: 400, opacity: 0 }}


### PR DESCRIPTION
## Summary
- Fixed React warning: "Encountered two children with the same key, ``"
- Added `key={location.id}` to `motion.aside` element in RightDetailPanel
- Ensures AnimatePresence can properly track component animations

## Problem
The `RightDetailPanel` component uses Framer Motion's `AnimatePresence` to animate the panel in/out. However, the direct child (`motion.aside`) didn't have a unique key prop, causing React to assign empty keys and trigger duplicate key warnings.

## Solution
Added `key={location.id}` to the `motion.aside` element. This ensures:
- Each location gets a unique animation instance
- AnimatePresence can properly track which component is entering/exiting
- No more duplicate key warnings
- Smooth animations are preserved

## Test Plan
- [x] Open the app and click on a location to open RightDetailPanel
- [x] Switch between different locations
- [x] Verify no console warnings about duplicate keys
- [x] Confirm panel animations still work smoothly

## Files Changed
- `src/components/Layout/RightDetailPanel.tsx` - Added key prop to motion.aside

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animation stability when navigating between different views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->